### PR TITLE
Fix Guzzle client options to better work with injected clients

### DIFF
--- a/src/Credit.php
+++ b/src/Credit.php
@@ -92,7 +92,7 @@ final class Credit implements HateoasInterface
      */
     private $createdAt;
     /**
-     * @var null|string
+     * @var string|null
      */
     private $clientReference;
 


### PR DESCRIPTION
Guzzle’s `http_errors` option is a request-level option. Our code assumed this was always `false`, but that may not be the case if the Guzzle client is injected, which would cause uncaught exceptions on 4xx or 5xx response codes from the API.

This PR fixes it to more reliably work with injected Guzzle clients.