### PR TITLE
Add Guzzle 7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ php:
     - 7.2
     - 7.3
 
+env:
+    - GUZZLE_VERSION="^6.0"
+    - GUZZLE_VERSION="^7.0"
+
 install:
-    - composer install
+    - composer require guzzlehttp/guzzle:${GUZZLE_VERSION}
 
 script: php vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
     - GUZZLE_VERSION="^6.0"
     - GUZZLE_VERSION="^7.0"
 
+jobs:
+    exclude:
+        -   php: 7.1
+            env: GUZZLE_VERSION="^7.0"
+
 install:
     - composer require guzzlehttp/guzzle:${GUZZLE_VERSION}
 

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,12 @@
     },
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "moneyphp/money": "^3.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "alexeyshockov/guzzle-psalm-plugin": "^0.1.0",
+        "alexeyshockov/guzzle-psalm-plugin": "^0.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "phpunit/phpunit": "^7.0",
         "vimeo/psalm": "^3.4"


### PR DESCRIPTION
This PR adds support for Guzzle 7 (`guzzlehttp/guzzle:^7.0`). It maintains existing compatibility with Guzzle 6 and contains no BC breaks.