### PR TITLE
Updated psr/logger to support versions 2 and 3.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         },
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "ocramius/package-versions": true
         }
     },
     "autoload": {
@@ -37,7 +38,7 @@
         "php": "^7.4 || ^8.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "moneyphp/money": "^3.0 || ^4.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "alexeyshockov/guzzle-psalm-plugin": "^0.3.1",


### PR DESCRIPTION
This adds version 2 and 3 support of the PSR logger. It also adds the non-legacy `ocramius/package-versions` to the plugins list.